### PR TITLE
Make the contact link go to the correct page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -124,7 +124,7 @@
     <div class="row">
       <div class="small-12 columns">
         <header class="c-contact-bar-header u-stacked-medium-down">
-          <h3 class="c-contact-bar__heading"> <a href="{{ '/kontakt/' | relative_url }}">Contact</a> </h3>
+          <h3 class="c-contact-bar__heading"> <a href="{{ '/contact/' | relative_url }}">Contact</a> </h3>
         </header>
         <ul class="c-contact-bar-items u-stacked-medium-down">
           <li class="c-contact-bar__item u-stacked-medium-down">


### PR DESCRIPTION
Was going to the non-english path