### PR TITLE
Footer hide calendar

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -57,9 +57,9 @@
                 <li class="c-vertical-navigation__item">
                   <a href="{{ 'news/' | relative_url }}">News</a>
                 </li>
-                <li class="c-vertical-navigation__item">
+                {% comment %} <li class="c-vertical-navigation__item">
                   <a href="{{ 'join-us/kalendar/' | relative_url }}">Calendar</a>
-                </li>
+                </li> {% endcomment %}
               </ul>
             </nav>
           </div>


### PR DESCRIPTION
Hides the Calendar footer link as a workaround for #15 until we fix properly 