### PR TITLE
Remove link to membership portal

### DIFF
--- a/_data/top-menu.yml
+++ b/_data/top-menu.yml
@@ -4,6 +4,3 @@
 - link: Pirate Shop
   url: https://www.zazzle.co.uk/piratepartyuk
   icon: fa fa-shopping-basket
-- link: Members Portal
-  url: https://legacy.pirateparty.org.uk
-  icon: fa fa-home

--- a/_data/top-menu.yml
+++ b/_data/top-menu.yml
@@ -1,6 +1,3 @@
 - link: Discord
   url: http://discord.pirateparty.org.uk
   icon: fa fa-comments
-- link: Pirate Shop
-  url: https://www.zazzle.co.uk/piratepartyuk
-  icon: fa fa-shopping-basket


### PR DESCRIPTION
Somehow, this subdomain has been compromised and no longer goes to the drupal site